### PR TITLE
Fixes git clone command to use github instead of gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## How to install
 
 ```bash
-git clone git@gitlab.com:kejawenlab/skeleton.git Semart
+git clone https://github.com/KejawenLab/Skeleton.git Semart
 
 cd Semart
 
@@ -25,7 +25,7 @@ php bin/console semart:install
 ## KejawenLab Love Docker
 
 ```bash
-git clone git@gitlab.com:kejawenlab/skeleton.git Semart
+git clone https://github.com/KejawenLab/Skeleton.git Semart
 
 cd Semart 
 

--- a/doc/intallation.md
+++ b/doc/intallation.md
@@ -14,7 +14,7 @@
 
 - Install [Docker](https://docs.docker.com/v17.09/engine/installation) and [Docker Compose](https://docs.docker.com/compose/install/)
 
-- Clone repository `git clone git@gitlab.com:kejawenlab/skeleton.git Semart`
+- Clone repository `git clone https://github.com/KejawenLab/Skeleton.git Semart`
 
 - Change to project root `cd Semart`
 
@@ -36,7 +36,7 @@
 
 - Install Requirements
 
-- Clone repository `git clone git@gitlab.com:kejawenlab/skeleton.git Semart`
+- Clone repository `git clone https://github.com/KejawenLab/Skeleton.git Semart`
 
 - Change to project root `cd Semart`
 


### PR DESCRIPTION
it seems it was migrated from gitlab. It seems the gitlab repo not found or need access for it:

```
GitLab: The project you were looking for could not be found.
fatal: Could not read from remote repository.
```

Updated to use github instead with this repo url.