### PR TITLE
coveralls settings

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+coverage_clover: build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ services:
 before_script:
   - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer install --prefer-dist
+  - composer require --dev php-coveralls/php-coveralls
+  - mkdir -p build/logs
 
 script:
-  - php vendor/bin/phpunit -c phpunit.xml.travis.dist
+  - bin/phpunit -c phpunit.xml.travis.dist
+  - bin/php-coveralls -v --exclude-no-stmt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Semart Skeleton
 
 [![Build Status](https://travis-ci.org/KejawenLab/SemartSkeleton.svg?branch=master)](https://travis-ci.org/KejawenLab/SemartSkeleton)
+[![Coverage Status](https://coveralls.io/repos/github/KejawenLab/SemartSkeleton/badge.svg?branch=master)](https://coveralls.io/github/KejawenLab/SemartSkeleton?branch=master)
 
 ## Tentang
 

--- a/phpunit.xml.travis.dist
+++ b/phpunit.xml.travis.dist
@@ -50,4 +50,8 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
+
+    <logging>
+        <log type="coverage-clover" target="./build/logs/clover.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
Berikut coveralls.io service jika diapprove. Flow pada saat build-nya sebagai berikut:

- menambah dev dependency `php-coveralls/php-coveralls`
- create directory `build/logs`
- run phpunit dengan membaca `phpunit.xml.travis.dist` dengan logging coverage clover ke `build/logs/clover.xml`
- run coveralls command dengan membaca config `.coveralls.yml`

Request untuk akses coveralls sudah dikirim, mungkin bisa cek email:

![coveralls io](https://user-images.githubusercontent.com/459648/55379123-01eea700-5546-11e9-8e82-077998aa4c9e.png)

Jika diapprove, nanti kita bisa ceklist reponya di https://coveralls.io/repos/new seperti berikut:

![ceklist-coveralls](https://user-images.githubusercontent.com/459648/55379184-56922200-5546-11e9-9456-7da824cfdd0e.png)

Kalau sudah diceklist, bisa uncheck `"Leave comments?"` option di halaman setting reponya, misalnya: https://coveralls.io/github/KejawenLab/SemartSkeleton/settings sehingga yang aktif cuma `"Use status API?"` option seperti berikut:

![enable-status-api](https://user-images.githubusercontent.com/459648/55379320-e33ce000-5546-11e9-87d2-0ac017665b0e.png)





