### PR TITLE
fix travis build : test pagination query should be "p" instead of "page"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 
 # cs
 /.php_cs.cache
+/.phpunit.result.cache

--- a/tests/Pagination/PaginationExtensionTest.php
+++ b/tests/Pagination/PaginationExtensionTest.php
@@ -60,7 +60,7 @@ class PaginationExtensionTest extends TestCase
 
         $this->assertEquals(1, (new PaginationExtension($requestStackMock, $service))->startPageNumber());
 
-        $request->query->set('page', 2);
+        $request->query->set('p', 2);
 
         $this->assertEquals(Paginator::PER_PAGE + 1, (new PaginationExtension($requestStackMock, $service))->startPageNumber());
     }
@@ -68,7 +68,7 @@ class PaginationExtensionTest extends TestCase
     public function testGetFunctions()
     {
         $request = Request::createFromGlobals();
-        $request->query->set('page', 1);
+        $request->query->set('p', 1);
 
         $requestStackMock = $this->getMockBuilder(RequestStack::class)->disableOriginalConstructor()->getMock();
         $requestStackMock


### PR DESCRIPTION
Fixing test pagination, query harusnya "p", bukan "page" berdasarkan kode program di `PaginationExtension` class.