### PR TITLE
javascript fix: reset select box to index 0 + re-run select2()

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -251,8 +251,8 @@
             let form = $('#semartForm');
 
             form.trigger('reset');
-            form.find('select').prop('selectedIndex', 0);
             select = form.find('select');
+            select.prop('selectedIndex', 0);
             if (select.hasClass('select2-static')) {
                 select.select2();
             }

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -253,9 +253,11 @@
             form.trigger('reset');
             let select = form.find('select');
             select.prop('selectedIndex', 0);
-            if (select.hasClass('select2-static')) {
-                select.select2();
-            }
+            $.each(select, function() {
+                if ($(this).hasClass('select2-static')) {
+      		        $(this).select2();
+                }
+            });
             if ('function' === typeof callback) {
                 callback();
             }

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -255,7 +255,7 @@
             select.prop('selectedIndex', 0);
             $.each(select, function() {
                 if ($(this).hasClass('select2-static')) {
-      		        $(this).select2();
+                    $(this).select2();
                 }
             });
             if ('function' === typeof callback) {

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -251,7 +251,11 @@
             let form = $('#semartForm');
 
             form.trigger('reset');
-            form.find('select').val('');
+            form.find('select').prop('selectedIndex', 0);
+            select = form.find('select');
+            if (select.hasClass('select2-static')) {
+                select.select2();
+            }
             if ('function' === typeof callback) {
                 callback();
             }

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -251,7 +251,7 @@
             let form = $('#semartForm');
 
             form.trigger('reset');
-            select = form.find('select');
+            let select = form.find('select');
             select.prop('selectedIndex', 0);
             if (select.hasClass('select2-static')) {
                 select.select2();


### PR DESCRIPTION
Javascript fix untuk me-*reset* select box pada saat modal box diopen:

**Step to reproduce**:

- buka halaman admin user
- klik button tambah
- pilih group "SUPER ADMINISTRATOR"
- klik button batal
- klik lagi button tambah

select box harus kembali ke posisi index 0, dan karena ada use case di mana select box dirender menggunakan `select2()` function untuk select box yang mempunyai  class "select2-static", maka dicek dulu jika select tersebut punya class "select2-static", maka dipanggil function `select2()` setelah posisi index di-*reset* ke 0.